### PR TITLE
Include a commented out option to use PDO

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,9 @@
 FROM php:8.0.0-apache
 ARG DEBIAN_FRONTEND=noninteractive
 RUN docker-php-ext-install mysqli
+# Include alternative DB driver
+# RUN docker-php-ext-install pdo
+# RUN docker-php-ext-install pdo_mysql
 RUN apt-get update \
     && apt-get install -y sendmail libpng-dev \
     && apt-get install -y libzip-dev \


### PR DESCRIPTION
So, maybe this isn't in line with the project concept, if that's the case feel free to reject. It is being useful for me.

Just including a commented out section in the Dockerfile to install the PDO db driver. 

Of course I guess it could also be done in a fancier way.

Thanks for this project!